### PR TITLE
Remove dueOn date filter option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.1.2]
 ### Added
+- New due date filters for `dueAfter` and `dueBefore` to narrow results to a specific window or day
 - Support for fetching and embedding a Linear issue by its ID using a code block (`id: ISSUE_ID`).
   - Example:
     ````markdown

--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ To show issues assigned to a specific person, use the `assignee` option with the
 assignee: user@example.com
 ```
 
+#### Filter by Due Date
+
+You can narrow results by due date using the `dueAfter` and `dueBefore` options. These values accept either an ISO date (`YYYY-MM-DD`) or the keywords `today`, `tomorrow`, and `yesterday`.
+
+```linear
+dueAfter: 2024-05-01      # Issues due on or after May 1, 2024
+dueBefore: tomorrow       # Issues due before tomorrow
+```
+
+To focus on a single day, set `dueAfter` to the day you care about and `dueBefore` to the following day:
+
+```linear
+dueAfter: today
+dueBefore: tomorrow       # Issues due today by combining both filters
+```
+
+Combine `dueAfter` and `dueBefore` to create date ranges or target a specific day.
+
 #### Sort by Due Date
 
 To sort issues by their due date, use the `sorting` option:


### PR DESCRIPTION
## Summary
- drop the `dueOn` parsing logic and related Linear service handling so date filters rely on before/after ranges only
- simplify the shared `DateFilter` type guard to ensure only before/after values are considered valid
- update the documentation to describe targeting a single day by combining `dueAfter` and `dueBefore`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3dd8eac40832b85171644c1def584